### PR TITLE
Add sad emote field effect

### DIFF
--- a/asm/macros/movement.inc
+++ b/asm/macros/movement.inc
@@ -173,6 +173,7 @@
         create_movement_action emote_thinking, MOVEMENT_ACTION_EMOTE_THINKING
         create_movement_action emote_versus, MOVEMENT_ACTION_EMOTE_VERSUS
         create_movement_action emote_happy, MOVEMENT_ACTION_EMOTE_HAPPY
+        create_movement_action emote_sad, MOVEMENT_ACTION_EMOTE_SAD
         create_movement_action emote_sleeping, MOVEMENT_ACTION_EMOTE_SLEEPING
         create_movement_action walk_slow_stairs_down, MOVEMENT_ACTION_WALK_SLOW_STAIRS_DOWN
 	create_movement_action walk_slow_stairs_up, MOVEMENT_ACTION_WALK_SLOW_STAIRS_UP

--- a/data/field_effect_scripts.s
+++ b/data/field_effect_scripts.s
@@ -88,6 +88,7 @@ gFieldEffectScriptPointers::
         .4byte gFldEffScript_VersusIcon                @ FLDEFF_VERSUS_ICON
         .4byte gFldEffScript_HappyIcon                 @ FLDEFF_HAPPY_ICON
         .4byte gFldEffScript_SleepingIcon              @ FLDEFF_SLEEPING_ICON
+        .4byte gFldEffScript_SadIcon                   @ FLDEFF_SAD_ICON
 
 gFieldEffectScript_ExclamationMarkIcon1::
 	field_eff_callnative FldEff_ExclamationMarkIcon
@@ -390,6 +391,10 @@ gFldEffScript_HappyIcon::
 
 gFldEffScript_SleepingIcon::
         field_eff_callnative FldEff_SleepingIcon
+        field_eff_end
+
+gFldEffScript_SadIcon::
+        field_eff_callnative FldEff_SadIcon
         field_eff_end
 
 gFieldEffectScript_TracksBug::

--- a/data/scripts/movement.inc
+++ b/data/scripts/movement.inc
@@ -272,19 +272,30 @@ Common_Movement_VersusWithDelay48:
 	step_end
 
 Common_Movement_Happy:
-	emote_happy
-	step_end
+        emote_happy
+        step_end
 
 Common_Movement_HappyWithDelay48:
-	emote_happy
-	delay_16
-	delay_16
-	delay_16
-	step_end
+        emote_happy
+        delay_16
+        delay_16
+        delay_16
+        step_end
+
+Common_Movement_Sad:
+        emote_sad
+        step_end
+
+Common_Movement_SadWithDelay48:
+        emote_sad
+        delay_16
+        delay_16
+        delay_16
+        step_end
 
 Common_Movement_Sleeping:
-	emote_sleeping
-	step_end
+        emote_sleeping
+        step_end
 
 Common_Movement_SmokeCigarette:
 	smoke_cigarette

--- a/include/constants/event_object_movement.h
+++ b/include/constants/event_object_movement.h
@@ -276,6 +276,7 @@
 #define MOVEMENT_ACTION_JUMP_3_UP                       0xB9
 #define MOVEMENT_ACTION_JUMP_3_LEFT                     0xBA
 #define MOVEMENT_ACTION_JUMP_3_RIGHT                    0xBB
+#define MOVEMENT_ACTION_EMOTE_SAD                       0xBC
 
 #define MOVEMENT_ACTION_STEP_END 0xFE
 #define MOVEMENT_ACTION_NONE     0xFF

--- a/include/constants/field_effects.h
+++ b/include/constants/field_effects.h
@@ -84,6 +84,7 @@
 #define FLDEFF_VERSUS_ICON         79
 #define FLDEFF_HAPPY_ICON          80
 #define FLDEFF_SLEEPING_ICON       81
+#define FLDEFF_SAD_ICON            82
 
 #define FLDEFFOBJ_SHADOW_S              0
 #define FLDEFFOBJ_SHADOW_M              1

--- a/include/event_object_movement.h
+++ b/include/event_object_movement.h
@@ -496,6 +496,7 @@ bool8 MovementAction_EmoteSweatDrop_Step0(struct ObjectEvent *, struct Sprite *)
 bool8 MovementAction_EmoteThinking_Step0(struct ObjectEvent *, struct Sprite *);
 bool8 MovementAction_EmoteVersus_Step0(struct ObjectEvent *, struct Sprite *);
 bool8 MovementAction_EmoteHappy_Step0(struct ObjectEvent *, struct Sprite *);
+bool8 MovementAction_EmoteSad_Step0(struct ObjectEvent *, struct Sprite *);
 bool8 MovementAction_EmoteSleeping_Step0(struct ObjectEvent *, struct Sprite *);
 bool8 MovementAction_EmoteSleeping_Step1(struct ObjectEvent *, struct Sprite *);
 

--- a/include/trainer_see.h
+++ b/include/trainer_see.h
@@ -33,5 +33,6 @@ u8 FldEff_ThinkingIcon(void);
 u8 FldEff_VersusIcon(void);
 u8 FldEff_HappyIcon(void);
 u8 FldEff_SleepingIcon(void);
+u8 FldEff_SadIcon(void);
 
 #endif // GUARD_TRAINER_SEE_H

--- a/src/data/object_events/movement_action_func_tables.h
+++ b/src/data/object_events/movement_action_func_tables.h
@@ -472,6 +472,7 @@ u8 (*const gMovementActionFuncs_EmoteThinking[])(struct ObjectEvent *, struct Sp
 u8 (*const gMovementActionFuncs_EmoteVersus[])(struct ObjectEvent *, struct Sprite *);
 u8 (*const gMovementActionFuncs_EmoteSleeping[])(struct ObjectEvent *, struct Sprite *);
 u8 (*const gMovementActionFuncs_EmoteHappy[])(struct ObjectEvent *, struct Sprite *);
+u8 (*const gMovementActionFuncs_EmoteSad[])(struct ObjectEvent *, struct Sprite *);
 u8 (*const gMovementActionFuncs_RunDownSlow[])(struct ObjectEvent *, struct Sprite *);
 u8 (*const gMovementActionFuncs_RunUpSlow[])(struct ObjectEvent *, struct Sprite *);
 u8 (*const gMovementActionFuncs_RunLeftSlow[])(struct ObjectEvent *, struct Sprite *);
@@ -660,6 +661,7 @@ u8 (*const *const gMovementActionFuncs[])(struct ObjectEvent *, struct Sprite *)
     [MOVEMENT_ACTION_EMOTE_THINKING] = gMovementActionFuncs_EmoteThinking,
     [MOVEMENT_ACTION_EMOTE_VERSUS] = gMovementActionFuncs_EmoteVersus,
     [MOVEMENT_ACTION_EMOTE_HAPPY] = gMovementActionFuncs_EmoteHappy,
+    [MOVEMENT_ACTION_EMOTE_SAD] = gMovementActionFuncs_EmoteSad,
     [MOVEMENT_ACTION_EMOTE_SLEEPING] = gMovementActionFuncs_EmoteSleeping,
     [MOVEMENT_ACTION_EMOTE_DOUBLE_EXCL_MARK] = gMovementActionFuncs_EmoteDoubleExclMark,
     [MOVEMENT_ACTION_EXIT_POKEBALL] = gMovementActionFuncs_ExitPokeball,
@@ -1660,6 +1662,11 @@ u8 (*const gMovementActionFuncs_EmoteVersus[])(struct ObjectEvent *, struct Spri
 
 u8 (*const gMovementActionFuncs_EmoteHappy[])(struct ObjectEvent *, struct Sprite *) = {
     MovementAction_EmoteHappy_Step0,
+    MovementAction_Finish,
+};
+
+u8 (*const gMovementActionFuncs_EmoteSad[])(struct ObjectEvent *, struct Sprite *) = {
+    MovementAction_EmoteSad_Step0,
     MovementAction_Finish,
 };
 

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -11026,6 +11026,14 @@ bool8 MovementAction_EmoteHappy_Step0(struct ObjectEvent *objectEvent, struct Sp
     return TRUE;
 }
 
+bool8 MovementAction_EmoteSad_Step0(struct ObjectEvent *objectEvent, struct Sprite *sprite)
+{
+    ObjectEventGetLocalIdAndMap(objectEvent, &gFieldEffectArguments[0], &gFieldEffectArguments[1], &gFieldEffectArguments[2]);
+    FieldEffectStart(FLDEFF_SAD_ICON);
+    sprite->sActionFuncId = 1;
+    return TRUE;
+}
+
 bool8 MovementAction_EmoteSleeping_Step0(struct ObjectEvent *objectEvent, struct Sprite *sprite)
 {
     StartSpriteAnimInDirection(objectEvent, sprite, DIR_SOUTH, ANIM_SLEEPING);

--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -70,6 +70,7 @@ static const u8 sEmotion_SweatDropGfx[] = INCBIN_U8("graphics/field_effects/pics
 static const u8 sEmotion_ThinkingGfx[] = INCBIN_U8("graphics/field_effects/pics/emotion_thinking.4bpp");
 static const u8 sEmotion_VersusGfx[] = INCBIN_U8("graphics/field_effects/pics/emotion_versus.4bpp");
 static const u8 sEmotion_HappyGfx[] = INCBIN_U8("graphics/field_effects/pics/emotion_happy.4bpp");
+static const u8 sEmotion_SadGfx[] = INCBIN_U8("graphics/field_effects/pics/emotion_sad.4bpp");
 static const u8 sEmotion_SleepingGfx[] = INCBIN_U8("graphics/field_effects/pics/emotion_sleeping.4bpp");
 // HGSS emote graphics ripped by Lemon on The Spriters Resource: https://www.spriters-resource.com/ds_dsi/pokemonheartgoldsoulsilver/sheet/30497/
 static const u8 sEmotion_Gfx[] = INCBIN_U8("graphics/misc/emotes.4bpp");
@@ -171,6 +172,10 @@ static const struct SpriteFrameImage sSpriteImageTable_ExclamationQuestionMark[]
     {
         .data = sEmotion_HappyGfx,
         .size = sizeof(sEmotion_HappyGfx)
+    },
+    {
+        .data = sEmotion_SadGfx,
+        .size = sizeof(sEmotion_SadGfx)
     },
     {
         .data = sEmotion_SleepingGfx,
@@ -355,6 +360,12 @@ static const union AnimCmd sSpriteAnim_Icons9[] =
     ANIMCMD_END
 };
 
+static const union AnimCmd sSpriteAnim_Icons10[] =
+{
+    ANIMCMD_FRAME(9, 60),
+    ANIMCMD_END
+};
+
 static const union AnimCmd *const sSpriteAnimTable_Icons[] =
 {
     sSpriteAnim_Icons1,
@@ -365,7 +376,8 @@ static const union AnimCmd *const sSpriteAnimTable_Icons[] =
     sSpriteAnim_Icons6,
     sSpriteAnim_Icons7,
     sSpriteAnim_Icons8,
-    sSpriteAnim_Icons9
+    sSpriteAnim_Icons9,
+    sSpriteAnim_Icons10
 };
 
 static const union AnimCmd *const sSpriteAnimTable_Emotes[] =
@@ -1091,6 +1103,19 @@ u8 FldEff_SleepingIcon(void)
         SetIconSpriteData(&gSprites[spriteId], FLDEFF_EXCLAMATION_MARK_ICON, 8);
         UpdateSpritePaletteByTemplate(&sSpriteTemplate_ExclamationQuestionMark, &gSprites[spriteId]);
     }
+    return 0;
+}
+
+u8 FldEff_SadIcon(void)
+{
+    u8 spriteId = CreateSpriteAtEnd(&sSpriteTemplate_ExclamationQuestionMark, 0, 0, 0x53);
+
+    if (spriteId != MAX_SPRITES)
+    {
+        SetIconSpriteData(&gSprites[spriteId], FLDEFF_EXCLAMATION_MARK_ICON, 9);
+        UpdateSpritePaletteByTemplate(&sSpriteTemplate_ExclamationQuestionMark, &gSprites[spriteId]);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- add a new sad emotion field effect, movement action, and script constants
- wire the sad icon asset into the trainer icon animation tables and helper
- expose convenience movement scripts that use the sad emote
- remove the sad emotion PNG asset that is no longer required

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e16330cd20832f801d4cbd1047bd25