### PR TITLE
Add trainer sprites for Omega, Drive, Boo, and Katherine

### DIFF
--- a/include/constants/trainers.h
+++ b/include/constants/trainers.h
@@ -127,7 +127,11 @@
 #define TRAINER_PIC_OZUMAS                109
 #define TRAINER_PIC_WAR                   110
 #define TRAINER_PIC_SERGIO                111
-#define TRAINER_PIC_COUNT                 112
+#define TRAINER_PIC_OMEGA                 112
+#define TRAINER_PIC_DRIVE                 113
+#define TRAINER_PIC_BOO                   114
+#define TRAINER_PIC_KATHERINE             115
+#define TRAINER_PIC_COUNT                 116
 
 // The player back pics are assumed to alternate according to the gender values (MALE/FEMALE)
 #define TRAINER_BACK_PIC_BRENDAN                0

--- a/src/data/graphics/trainers.h
+++ b/src/data/graphics/trainers.h
@@ -337,6 +337,18 @@ const u16 gTrainerPalette_War[] = INCBIN_U16("graphics/trainers/palettes/admins/
 const u32 gTrainerFrontPic_Sergio[] = INCBIN_U32("graphics/trainers/front_pics/admins/sergio.4bpp.smol");
 const u16 gTrainerPalette_Sergio[] = INCBIN_U16("graphics/trainers/palettes/admins/sergio.gbapal");
 
+const u32 gTrainerFrontPic_Omega[] = INCBIN_U32("graphics/trainers/front_pics/admins/omega.4bpp.smol");
+const u16 gTrainerPalette_Omega[] = INCBIN_U16("graphics/trainers/palettes/admins/omega.gbapal");
+
+const u32 gTrainerFrontPic_Drive[] = INCBIN_U32("graphics/trainers/front_pics/admins/drive.4bpp.smol");
+const u16 gTrainerPalette_Drive[] = INCBIN_U16("graphics/trainers/palettes/admins/drive.gbapal");
+
+const u32 gTrainerFrontPic_Boo[] = INCBIN_U32("graphics/trainers/front_pics/admins/boo.4bpp.smol");
+const u16 gTrainerPalette_Boo[] = INCBIN_U16("graphics/trainers/palettes/admins/boo.gbapal");
+
+const u32 gTrainerFrontPic_Katherine[] = INCBIN_U32("graphics/trainers/front_pics/admins/katherine.4bpp.smol");
+const u16 gTrainerPalette_Katherine[] = INCBIN_U16("graphics/trainers/palettes/admins/katherine.gbapal");
+
 const u8 gTrainerBackPic_Brendan[] = INCBIN_U8("graphics/trainers/back_pics/brendan.4bpp");
 const u8 gTrainerBackPic_May[] = INCBIN_U8("graphics/trainers/back_pics/may.4bpp");
 const u8 gTrainerBackPic_Red[] = INCBIN_U8("graphics/trainers/back_pics/red.4bpp");
@@ -477,6 +489,10 @@ const struct TrainerSprite gTrainerSprites[] =
     TRAINER_SPRITE(TRAINER_PIC_JACK_JOHNSON, gTrainerFrontPic_JackJohnson, gTrainerPalette_JackJohnson),
     TRAINER_SPRITE(TRAINER_PIC_WAR, gTrainerFrontPic_War, gTrainerPalette_War),
     TRAINER_SPRITE(TRAINER_PIC_SERGIO, gTrainerFrontPic_Sergio, gTrainerPalette_Sergio),
+    TRAINER_SPRITE(TRAINER_PIC_OMEGA, gTrainerFrontPic_Omega, gTrainerPalette_Omega),
+    TRAINER_SPRITE(TRAINER_PIC_DRIVE, gTrainerFrontPic_Drive, gTrainerPalette_Drive),
+    TRAINER_SPRITE(TRAINER_PIC_BOO, gTrainerFrontPic_Boo, gTrainerPalette_Boo),
+    TRAINER_SPRITE(TRAINER_PIC_KATHERINE, gTrainerFrontPic_Katherine, gTrainerPalette_Katherine),
 };
 
 static const union AnimCmd sAnimCmd_Hoenn[] =


### PR DESCRIPTION
## Summary
- add new trainer front sprite and palette definitions for Omega, Drive, Boo, and Katherine
- register the new trainer sprites and constants so they can be used like the other admin portraits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30fc26248832f9a0deee9c3d6533c