### PR TITLE
Show obtain-item messages and use `additem` for Kecleon healing kit

### DIFF
--- a/data/scripts/wah_rooms_shared.pory
+++ b/data/scripts/wah_rooms_shared.pory
@@ -184,38 +184,78 @@ script WahRoomsShared_Kecleon_KitCuracion {
     switch(var(VAR_RESULT))
     {
         case 0:
-            giveitem(ITEM_MAX_REVIVE, 1)
+            setvar(VAR_0x8000, ITEM_MAX_REVIVE)
+            setvar(VAR_0x8001, 1)
+            additem(VAR_0x8000, VAR_0x8001)
             if (var(VAR_RESULT) == FALSE) {
                 call(WahRoomsShared_Kecleon_KitCuracion_BagFull)
                 return
             }
-            giveitem(ITEM_REVIVE, 2)
+            bufferitemnameplural(STR_VAR_2, VAR_0x8000, VAR_0x8001)
+            playfanfare(MUS_OBTAIN_ITEM)
+            msgbox(format("¡Tile te entregó {STR_VAR_2}!"), MSGBOX_AUTOCLOSE)
+            waitfanfare
+
+            setvar(VAR_0x8000, ITEM_REVIVE)
+            setvar(VAR_0x8001, 2)
+            additem(VAR_0x8000, VAR_0x8001)
             if (var(VAR_RESULT) == FALSE) {
                 call(WahRoomsShared_Kecleon_KitCuracion_BagFull)
                 return
             }
-            giveitem(ITEM_FULL_RESTORE, 3)
+            bufferitemnameplural(STR_VAR_2, VAR_0x8000, VAR_0x8001)
+            playfanfare(MUS_OBTAIN_ITEM)
+            msgbox(format("¡Tile te entregó {STR_VAR_2}!"), MSGBOX_AUTOCLOSE)
+            waitfanfare
+
+            setvar(VAR_0x8000, ITEM_FULL_RESTORE)
+            setvar(VAR_0x8001, 3)
+            additem(VAR_0x8000, VAR_0x8001)
             if (var(VAR_RESULT) == FALSE) {
                 call(WahRoomsShared_Kecleon_KitCuracion_BagFull)
                 return
             }
+            bufferitemnameplural(STR_VAR_2, VAR_0x8000, VAR_0x8001)
+            playfanfare(MUS_OBTAIN_ITEM)
+            msgbox(format("¡Tile te entregó {STR_VAR_2}!"), MSGBOX_AUTOCLOSE)
+            waitfanfare
             break
         case 1:
-            giveitem(ITEM_REVIVE, 2)
+            setvar(VAR_0x8000, ITEM_REVIVE)
+            setvar(VAR_0x8001, 2)
+            additem(VAR_0x8000, VAR_0x8001)
             if (var(VAR_RESULT) == FALSE) {
                 call(WahRoomsShared_Kecleon_KitCuracion_BagFull)
                 return
             }
-            giveitem(ITEM_MAX_POTION, 2)
+            bufferitemnameplural(STR_VAR_2, VAR_0x8000, VAR_0x8001)
+            playfanfare(MUS_OBTAIN_ITEM)
+            msgbox(format("¡Tile te entregó {STR_VAR_2}!"), MSGBOX_AUTOCLOSE)
+            waitfanfare
+
+            setvar(VAR_0x8000, ITEM_MAX_POTION)
+            setvar(VAR_0x8001, 2)
+            additem(VAR_0x8000, VAR_0x8001)
             if (var(VAR_RESULT) == FALSE) {
                 call(WahRoomsShared_Kecleon_KitCuracion_BagFull)
                 return
             }
-            giveitem(ITEM_FULL_HEAL, 2)
+            bufferitemnameplural(STR_VAR_2, VAR_0x8000, VAR_0x8001)
+            playfanfare(MUS_OBTAIN_ITEM)
+            msgbox(format("¡Tile te entregó {STR_VAR_2}!"), MSGBOX_AUTOCLOSE)
+            waitfanfare
+
+            setvar(VAR_0x8000, ITEM_FULL_HEAL)
+            setvar(VAR_0x8001, 2)
+            additem(VAR_0x8000, VAR_0x8001)
             if (var(VAR_RESULT) == FALSE) {
                 call(WahRoomsShared_Kecleon_KitCuracion_BagFull)
                 return
             }
+            bufferitemnameplural(STR_VAR_2, VAR_0x8000, VAR_0x8001)
+            playfanfare(MUS_OBTAIN_ITEM)
+            msgbox(format("¡Tile te entregó {STR_VAR_2}!"), MSGBOX_AUTOCLOSE)
+            waitfanfare
             break
     }
     return


### PR DESCRIPTION
### Motivation
- Ensure players receive explicit obtain-item feedback and fanfare when Kecleon gives items as part of the healing kit. 
- Standardize item granting to use variable-based `additem` calls so bag-full checks and results are handled consistently. 

### Description
- Replaced direct `giveitem(...)` calls in `WahRoomsShared_Kecleon_KitCuracion` with `setvar` + `additem` sequences using `VAR_0x8000`/`VAR_0x8001` to pass item ID and quantity. 
- After each successful `additem`, added `bufferitemnameplural(STR_VAR_2, ...)`, `playfanfare(MUS_OBTAIN_ITEM)`, `msgbox(format("¡Tile te entregó {STR_VAR_2}!"), MSGBOX_AUTOCLOSE)`, and `waitfanfare` to show the obtained item name and play the fanfare. 
- Preserved existing bag-full handling by keeping the `WahRoomsShared_Kecleon_KitCuracion_BagFull` calls when `additem` reports failure. 
- Added a trailing newline at end of `wah_rooms_shared.pory`. 

### Testing
- Compiled the project scripts (`poryscript`/script compilation step) and verified the modified script compiles without errors. 
- Performed a full project build which completed successfully, indicating no integration compile-time errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6cf22ba14832fa3be9e47a2be97d5)