### PR TITLE
Usar color de género del jugador para nombre del mapa en menú de guardado

### DIFF
--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -1734,7 +1734,7 @@ static void ShowSaveInfoWindow(void)
 
     // Print region name
     yOffset = 1;
-    BufferSaveMenuText(SAVE_MENU_LOCATION, gStringVar4, TEXT_COLOR_GREEN);
+    BufferSaveMenuText(SAVE_MENU_LOCATION, gStringVar4, color);
     AddTextPrinterParameterized(sSaveInfoWindowId, FONT_NORMAL, gStringVar4, 0, yOffset, TEXT_SKIP_DRAW, NULL);
 
     // Print player name


### PR DESCRIPTION
### Motivation
- Hacer que el texto del nombre del mapa en la ventana de guardado use el mismo color dependiente del género del jugador (azul para masculino, rojo para femenino) en vez del verde estático para mantener la coherencia visual.

### Description
- Reemplacé `TEXT_COLOR_GREEN` por la variable `color` en la llamada a `BufferSaveMenuText(SAVE_MENU_LOCATION, gStringVar4, ...)` dentro de `src/start_menu.c`, de modo que el color se derive de `gSaveBlock2Ptr->playerGender`.

### Testing
- No se ejecutaron pruebas automatizadas; el cambio es una corrección de una línea en la interfaz de usuario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eec491e44832f9d4749ee656a3f6f)