### PR TITLE
Alexmad: mostrar mensaje al volver del PC tras intercambiar Pokémon

### DIFF
--- a/data/maps/CollaboratorsRoom/scripts.inc
+++ b/data/maps/CollaboratorsRoom/scripts.inc
@@ -2154,6 +2154,13 @@ WahRoomsShared_EventScript_WalkInPlaceAlexmadFacingPlayer_6:
 	goto WahRoomsShared_EventScript_WalkInPlaceAlexmadFacingPlayer_1
 
 
+CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete::
+	lockall
+	msgbox CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete_Text_0, MSGBOX_AUTOCLOSE, speaker = SP_NAME_ALEXMAD
+	goto CollaboratorsRoom_EventScript_Alexmad_OnFinishEvent
+	return
+
+
 CollaboratorsRoom_EventScript_AlexmadPuzzleFailed::
 # 1174 "data/maps/CollaboratorsRoom/scripts.pory"
 	lockall
@@ -3697,6 +3704,9 @@ CollaboratorsRoom_EventScript_AlexmadPuzzleComplete_Text_8:
 	.string "KODER hubiera sonreído al verte salir\n"
 	.string "de aquí con tantas cartas en la manga.\p"
 	.string "No lo desperdicies.$"
+
+CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete_Text_0:
+	.string "Bien ahí, te falta un último paso.$"
 
 CollaboratorsRoom_EventScript_AlexmadPuzzleFailed_Text_0:
 # 1178 "data/maps/CollaboratorsRoom/scripts.pory"

--- a/data/maps/CollaboratorsRoom/scripts.pory
+++ b/data/maps/CollaboratorsRoom/scripts.pory
@@ -1170,6 +1170,13 @@ script WahRoomsShared_EventScript_WalkInPlaceAlexmadFacingPlayer {
     return
 }
 
+
+script CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete {
+    lockall
+    msgbox(format("Bien ahí, te falta un último paso."), MSGBOX_AUTOCLOSE, speaker = SP_NAME_ALEXMAD)
+    goto(CollaboratorsRoom_EventScript_Alexmad_OnFinishEvent)
+}
+
 script CollaboratorsRoom_EventScript_AlexmadPuzzleFailed {
     lockall
     applymovementandwait(LOCALID_COLLABORATORS_ROOM_ALEXMAD, Common_Movement_FacePlayer)

--- a/include/event_scripts.h
+++ b/include/event_scripts.h
@@ -584,6 +584,7 @@ extern const u8 AbnormalWeather_EventScript_EndEventAndCleanup_1[];
 extern const u8 IslandCave_EventScript_OpenRegiEntrance[];
 extern const u8 CollaboratorsRoom_EventScript_AlexmadPuzzleComplete[];
 extern const u8 CollaboratorsRoom_EventScript_AlexmadPuzzleFailed[];
+extern const u8 CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete[];
 extern const u8 MauvilleCity_EventScript_RegisterWallyCall[];
 extern const u8 Route119_EventScript_ScottWonAtFortreeGymCall[];
 extern const u8 LittlerootTown_ProfessorBirchsLab_EventScript_ScottAboardSSTidalCall[];

--- a/src/braille_puzzles.c
+++ b/src/braille_puzzles.c
@@ -342,6 +342,7 @@ bool8 ShouldDoBrailleRegicePuzzle(void)
 #define ALEXMAD_PUZZLE_RESULT_NONE    0
 #define ALEXMAD_PUZZLE_RESULT_SUCCESS 1
 #define ALEXMAD_PUZZLE_RESULT_FAIL    2
+#define ALEXMAD_PUZZLE_RESULT_SWAP_OK 3
 
 static const s8 sAlexmadStepOffsets[][2] =
 {
@@ -382,6 +383,12 @@ u8 ShouldDoAlexmadCornerPuzzle(void)
         return ALEXMAD_PUZZLE_RESULT_NONE;
 
     checkpoint = VarGet(VAR_ALEXMAD_PUZZLE_CHECKPOINT);
+
+    if (checkpoint == 0 && HasSwappedAlexmadPuzzlePartyLeadAndSixth())
+    {
+        VarSet(VAR_ALEXMAD_PUZZLE_CHECKPOINT, 1);
+        return ALEXMAD_PUZZLE_RESULT_SWAP_OK;
+    }
     if (checkpoint >= ARRAY_COUNT(sAlexmadStepOffsets))
         return ALEXMAD_PUZZLE_RESULT_NONE;
 

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -719,6 +719,11 @@ static bool8 TryStartStepCountScript(u16 metatileBehavior)
                 ScriptContext_SetupScript(CollaboratorsRoom_EventScript_AlexmadPuzzleFailed);
                 return TRUE;
             }
+            else if (alexmadResult == 3)
+            {
+                ScriptContext_SetupScript(CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete);
+                return TRUE;
+            }
         }
         if (ShouldDoWallyCall() == TRUE)
         {


### PR DESCRIPTION
### Motivation
- Mejorar la señalización del puzzle de Alexmad para que, al volver del PC tras intercambiar el 1.º y 6.º Pokémon, el jugador reciba feedback y el puzzle avance al siguiente paso.
- Evitar que la secuencia en el mapa falle por falta de respuesta tras realizar el intercambio desde la PC.

### Description
- `src/braille_puzzles.c` añade `ALEXMAD_PUZZLE_RESULT_SWAP_OK` y detecta cuando el jugador ya ha intercambiado el sexto y el líder, avanzando el `VAR_ALEXMAD_PUZZLE_CHECKPOINT` y devolviendo el nuevo resultado; esto permite continuar la secuencia sin reiniciar el puzzle.
- `src/field_control_avatar.c` incorpora manejo de `ALEXMAD_PUZZLE_RESULT_SWAP_OK` dentro de `TryStartStepCountScript` para invocar el nuevo evento `CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete` cuando corresponda.
- `include/event_scripts.h` declara el nuevo `extern` para `CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete`.
- `data/maps/CollaboratorsRoom/scripts.pory` y `data/maps/CollaboratorsRoom/scripts.inc` añaden el script `CollaboratorsRoom_EventScript_AlexmadPuzzleSwapComplete` y su cadena con el mensaje solicitado: `"Bien ahí, te falta un último paso."`.

### Testing
- Verifiqué la presencia de las referencias nuevas con `rg -n "AlexmadPuzzleSwapComplete|ALEXMAD_PUZZLE_RESULT_SWAP_OK" src include data/maps/CollaboratorsRoom/scripts.pory data/maps/CollaboratorsRoom/scripts.inc` y la búsqueda devolvió las ocurrencias esperadas.
- Inspeccioné las secciones editadas con `nl`/`sed` para confirmar que las líneas nuevas se insertaron en `src/braille_puzzles.c`, `src/field_control_avatar.c`, `include/event_scripts.h` y los archivos de scripts del mapa, y la verificación mostró los fragmentos esperados.
- Añadí y confirmé los cambios en el árbol de trabajo del repositorio local para su posterior revisión por CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12081c5ee4832f92e569ec09cd4eff)